### PR TITLE
Implement cancelQuery

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test:node": "vitest"
   },
   "peerDependencies": {
-    "kysely": ">= 0.24.0 < 1",
+    "kysely": ">= 0.29.0 < 1",
     "postgres": "^3.4.0"
   },
   "peerDependenciesMeta": {
@@ -65,8 +65,8 @@
     "@tsconfig/node24": "^24.0.1",
     "@types/bun": "^1.2.21",
     "@types/node": "^24.3.0",
-    "kysely": "^0.28.5",
-    "postgres": "^3.4.7",
+    "kysely": "^0.29.4",
+    "postgres": "^3.4.9",
     "std-env": "^3.9.0",
     "tsup": "^8.5.0",
     "typescript": "^5.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,11 +27,11 @@ importers:
         specifier: ^24.3.0
         version: 24.3.0
       kysely:
-        specifier: ^0.28.5
-        version: 0.28.5
+        specifier: ^0.29.4
+        version: 0.29.4
       postgres:
-        specifier: ^3.4.7
-        version: 3.4.7
+        specifier: ^3.4.9
+        version: 3.4.9
       std-env:
         specifier: ^3.9.0
         version: 3.9.0
@@ -799,9 +799,9 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  kysely@0.28.5:
-    resolution: {integrity: sha512-rlB0I/c6FBDWPcQoDtkxi9zIvpmnV5xoIalfCMSMCa7nuA6VGA3F54TW9mEgX4DVf10sXAWCF5fDbamI/5ZpKA==}
-    engines: {node: '>=20.0.0'}
+  kysely@0.29.4:
+    resolution: {integrity: sha512-y5mVgQNkMbs1eK9Xyc0pmNdabN2wHhRYY/5r4W5HrUT1rYCEPeVNSj1RUJeSDKT3U0p+mXCvLgkrFuIafYI6BA==}
+    engines: {node: '>=22.0.0'}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -938,8 +938,8 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postgres@3.4.7:
-    resolution: {integrity: sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==}
+  postgres@3.4.9:
+    resolution: {integrity: sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==}
     engines: {node: '>=12'}
 
   punycode@2.3.1:
@@ -1817,7 +1817,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  kysely@0.28.5: {}
+  kysely@0.29.4: {}
 
   lilconfig@3.1.3: {}
 
@@ -1929,7 +1929,7 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postgres@3.4.7: {}
+  postgres@3.4.9: {}
 
   punycode@2.3.1: {}
 

--- a/src/dialect-config.mts
+++ b/src/dialect-config.mts
@@ -40,8 +40,10 @@ export interface PostgresJSPendingQuery
 	extends Promise<any[] & Iterable<any> & PostgresJSResultQueryMeta> {
 	/**
 	 * Cancels this pending query on the database side, if supported. Present on
-	 * both `postgres`'s pending queries and Bun's `SQL`, though as of Bun 1.3.1
-	 * it doesn't actually cancel the in-flight query server-side.
+	 * both `postgres`'s pending queries and Bun's `SQL`, though Bun
+	 * `SQL`'s pending query `.cancel()` doesn't actually cancel the in-flight
+	 * query server-side. Because of that, `PostgresJSConnection.cancelQuery`
+	 * throws instead of calling this when running on Bun, rather than being a no-op.
 	 */
 	cancel?: () => void
 	// biome-ignore lint/suspicious/noExplicitAny: we wanna match widely, to be safe.

--- a/src/dialect-config.mts
+++ b/src/dialect-config.mts
@@ -1,17 +1,22 @@
-import type { DatabaseConnection } from 'kysely'
+import type { AbortableOperationOptions, DatabaseConnection } from 'kysely'
 
 export interface PostgresJSDialectConfig {
 	/**
 	 * Called every time a connection is acquired from the pool.
 	 */
-	onReserveConnection?: (connection: DatabaseConnection) => Promise<void>
+	onReserveConnection?: (
+		connection: DatabaseConnection,
+		options?: AbortableOperationOptions,
+	) => Promise<void>
 
 	/**
 	 * An instance, or a factory returning an instance, of `postgres`'s `Sql` (returned by `postgres(...)`) or Bun's `SQL` class.
 	 */
 	readonly postgres:
 		| PostgresJSSql
-		| (() => PostgresJSSql | Promise<PostgresJSSql>)
+		| ((
+				options?: AbortableOperationOptions,
+		  ) => PostgresJSSql | Promise<PostgresJSSql>)
 }
 
 export interface PostgresJSSql {
@@ -30,9 +35,15 @@ export interface PostgresJSReservedSql {
 	): PostgresJSPendingQuery
 }
 
-interface PostgresJSPendingQuery
+export interface PostgresJSPendingQuery
 	// biome-ignore lint/suspicious/noExplicitAny: we wanna match widely, to be safe.
 	extends Promise<any[] & Iterable<any> & PostgresJSResultQueryMeta> {
+	/**
+	 * Cancels this pending query on the database side, if supported. Present on
+	 * both `postgres`'s pending queries and Bun's `SQL`, though as of Bun 1.3.1
+	 * it doesn't actually cancel the in-flight query server-side.
+	 */
+	cancel?: () => void
 	// biome-ignore lint/suspicious/noExplicitAny: we wanna match widely, to be safe.
 	cursor?: (rows?: number) => AsyncIterable<any[]>
 	// | ((rows: number, cb: (rows: any[]) => void) => Promise<ExecutionResult>)

--- a/src/driver.mts
+++ b/src/driver.mts
@@ -1,4 +1,5 @@
 import {
+	type AbortableOperationOptions,
 	type CompiledQuery,
 	type DatabaseConnection,
 	PostgresDriver,
@@ -6,6 +7,7 @@ import {
 } from 'kysely'
 import type {
 	PostgresJSDialectConfig,
+	PostgresJSPendingQuery,
 	PostgresJSReservedSql,
 	PostgresJSSql,
 } from './dialect-config.mjs'
@@ -22,30 +24,35 @@ export class PostgresJSDriver extends PostgresDriver {
 		this.#config = freeze({ ...config })
 	}
 
-	override async acquireConnection(): Promise<PostgresJSConnection> {
+	override async acquireConnection(
+		options?: AbortableOperationOptions,
+	): Promise<PostgresJSConnection> {
 		// biome-ignore lint/style/noNonNullAssertion: `init` ran at this point.
 		const reservedConnection = await this.#postgres!.reserve()
 
 		const connection = new PostgresJSConnection(reservedConnection)
 
-		await this.#config.onReserveConnection?.(connection)
+		await this.#config.onReserveConnection?.(connection, options)
 
 		return connection
 	}
 
-	override async destroy(): Promise<void> {
+	override async destroy(_options?: AbortableOperationOptions): Promise<void> {
 		// biome-ignore lint/style/noNonNullAssertion: `init` ran at this point.
 		await this.#postgres!.end()
 	}
 
-	override async init(): Promise<void> {
+	override async init(options?: AbortableOperationOptions): Promise<void> {
 		const { postgres } = this.#config
 
-		this.#postgres = isPostgresJSSql(postgres) ? postgres : await postgres()
+		this.#postgres = isPostgresJSSql(postgres)
+			? postgres
+			: await postgres(options)
 	}
 
 	override async releaseConnection(
 		connection: DatabaseConnection,
+		_options?: AbortableOperationOptions,
 	): Promise<void> {
 		;(connection as PostgresJSConnection)[RELEASE_CONNECTION_SYMBOL]()
 	}
@@ -57,29 +64,44 @@ function isPostgresJSSql(thing: unknown): thing is PostgresJSSql {
 
 class PostgresJSConnection implements DatabaseConnection {
 	readonly #reservedConnection: PostgresJSReservedSql
+	#pendingQuery: PostgresJSPendingQuery | undefined
 
 	constructor(reservedConnection: PostgresJSReservedSql) {
 		this.#reservedConnection = reservedConnection
 	}
 
+	async cancelQuery(): Promise<void> {
+		if (typeof this.#pendingQuery?.cancel === 'function') {
+			this.#pendingQuery.cancel()
+		}
+	}
+
 	async executeQuery<R>(
 		compiledQuery: CompiledQuery<unknown>,
 	): Promise<QueryResult<R>> {
-		const result = await this.#reservedConnection.unsafe(compiledQuery.sql, [
+		const pendingQuery = this.#reservedConnection.unsafe(compiledQuery.sql, [
 			...compiledQuery.parameters,
 		])
 
-		const { command, count } = result
+		this.#pendingQuery = pendingQuery
 
-		return {
-			numAffectedRows:
-				command === 'INSERT' ||
-				command === 'UPDATE' ||
-				command === 'DELETE' ||
-				command === 'MERGE'
-					? BigInt(count)
-					: undefined,
-			rows: Array.from(result.values()),
+		try {
+			const result = await pendingQuery
+
+			const { command, count } = result
+
+			return {
+				numAffectedRows:
+					command === 'INSERT' ||
+					command === 'UPDATE' ||
+					command === 'DELETE' ||
+					command === 'MERGE'
+						? BigInt(count)
+						: undefined,
+				rows: Array.from(result.values()),
+			}
+		} finally {
+			this.#pendingQuery = undefined
 		}
 	}
 
@@ -101,10 +123,16 @@ class PostgresJSConnection implements DatabaseConnection {
 			)
 		}
 
+		this.#pendingQuery = query
+
 		const cursor = query.cursor(chunkSize)
 
-		for await (const rows of cursor) {
-			yield { rows }
+		try {
+			for await (const rows of cursor) {
+				yield { rows }
+			}
+		} finally {
+			this.#pendingQuery = undefined
 		}
 	}
 

--- a/src/driver.mts
+++ b/src/driver.mts
@@ -62,6 +62,14 @@ function isPostgresJSSql(thing: unknown): thing is PostgresJSSql {
 	return typeof thing === 'function' && 'reserve' in thing
 }
 
+function isBunSql(thing: unknown): boolean {
+	return (
+		typeof thing === 'function' &&
+		// biome-ignore lint/suspicious/noExplicitAny: we wanna match widely, to be safe.
+		typeof (thing as any).options?.adapter === 'string'
+	)
+}
+
 class PostgresJSConnection implements DatabaseConnection {
 	readonly #reservedConnection: PostgresJSReservedSql
 	#pendingQuery: PostgresJSPendingQuery | undefined
@@ -71,7 +79,17 @@ class PostgresJSConnection implements DatabaseConnection {
 	}
 
 	async cancelQuery(): Promise<void> {
-		this.#pendingQuery?.cancel?.()
+		if (!this.#pendingQuery) {
+			return
+		}
+
+		if (isBunSql(this.#reservedConnection)) {
+			throw new PostgresJSDialectError(
+				"Cancelling in-flight queries is not supported when running on Bun. Bun's `SQL` pending query `.cancel()` does not actually cancel the query on the database side.",
+			)
+		}
+
+		this.#pendingQuery.cancel?.()
 	}
 
 	async executeQuery<R>(

--- a/src/driver.mts
+++ b/src/driver.mts
@@ -71,22 +71,18 @@ class PostgresJSConnection implements DatabaseConnection {
 	}
 
 	async cancelQuery(): Promise<void> {
-		if (typeof this.#pendingQuery?.cancel === 'function') {
-			this.#pendingQuery.cancel()
-		}
+		this.#pendingQuery?.cancel?.()
 	}
 
 	async executeQuery<R>(
 		compiledQuery: CompiledQuery<unknown>,
 	): Promise<QueryResult<R>> {
-		const pendingQuery = this.#reservedConnection.unsafe(compiledQuery.sql, [
+		this.#pendingQuery = this.#reservedConnection.unsafe(compiledQuery.sql, [
 			...compiledQuery.parameters,
 		])
 
-		this.#pendingQuery = pendingQuery
-
 		try {
-			const result = await pendingQuery
+			const result = await this.#pendingQuery
 
 			const { command, count } = result
 
@@ -113,19 +109,18 @@ class PostgresJSConnection implements DatabaseConnection {
 			throw new PostgresJSDialectError('chunkSize must be a positive integer')
 		}
 
-		const query = this.#reservedConnection.unsafe(compiledQuery.sql, [
+		this.#pendingQuery = this.#reservedConnection.unsafe(compiledQuery.sql, [
 			...compiledQuery.parameters,
 		])
 
-		if (typeof query.cursor !== 'function') {
+		if (typeof this.#pendingQuery.cursor !== 'function') {
+			this.#pendingQuery = undefined
 			throw new Error(
 				'PostgresJSDialect detected the instance you passed to it does not support streaming.',
 			)
 		}
 
-		this.#pendingQuery = query
-
-		const cursor = query.cursor(chunkSize)
+		const cursor = this.#pendingQuery.cursor(chunkSize)
 
 		try {
 			for await (const rows of cursor) {

--- a/tests/crud.test.mts
+++ b/tests/crud.test.mts
@@ -379,20 +379,17 @@ for (const dialect of SUPPORTED_DIALECTS) {
 			},
 		)
 
-		it(
-			'should reject immediately when streaming with an already aborted signal',
-			async () => {
-				const controller = new AbortController()
-				const reason = new Error('aborted before streaming')
-				controller.abort(reason)
+		it('should reject immediately when streaming with an already aborted signal', async () => {
+			const controller = new AbortController()
+			const reason = new Error('aborted before streaming')
+			controller.abort(reason)
 
-				const iterator = ctx.db
-					.selectFrom('person')
-					.selectAll()
-					.stream({ signal: controller.signal })
+			const iterator = ctx.db
+				.selectFrom('person')
+				.selectAll()
+				.stream({ signal: controller.signal })
 
-				await expect(iterator.next()).rejects.toBe(reason)
-			},
-		)
+			await expect(iterator.next()).rejects.toBe(reason)
+		})
 	})
 }

--- a/tests/crud.test.mts
+++ b/tests/crud.test.mts
@@ -269,6 +269,7 @@ for (const dialect of SUPPORTED_DIALECTS) {
 			const controller = new AbortController()
 			const reason = new Error('aborted before execution')
 			controller.abort(reason)
+			vi.spyOn(console, 'error').mockImplementation(() => {})
 
 			await expect(
 				ctx.db
@@ -301,7 +302,14 @@ for (const dialect of SUPPORTED_DIALECTS) {
 							inflightQueryAbortStrategy: 'cancel query',
 						},
 					),
-				).rejects.toThrow()
+				).rejects.toSatisfy((error) => {
+					expect(error).toBeInstanceOf(DOMException)
+					expect(error).toMatchObject({
+						name: 'TimeoutError',
+						__kysely_timing__: 'during query execution',
+					})
+					return true
+				})
 
 				// give the sleep plenty of time to finish, in case the update
 				// wasn't actually cancelled on the database side.
@@ -332,7 +340,14 @@ for (const dialect of SUPPORTED_DIALECTS) {
 							inflightQueryAbortStrategy: 'cancel query',
 						},
 					),
-				).rejects.toThrow()
+				).rejects.toSatisfy((error) => {
+					expect(error).toBeInstanceOf(DOMException)
+					expect(error).toMatchObject({
+						name: 'TimeoutError',
+						message: 'The operation timed out.',
+					})
+					return true
+				})
 
 				// the background inflight-query-abort-handler failure is only
 				// reported asynchronously, after the execute() call above

--- a/tests/crud.test.mts
+++ b/tests/crud.test.mts
@@ -1,6 +1,14 @@
 import { sql } from 'kysely'
 import { isBun } from 'std-env'
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+} from 'vitest'
 import {
 	initTest,
 	resetState,
@@ -284,10 +292,6 @@ for (const dialect of SUPPORTED_DIALECTS) {
 			expect(Date.now() - start).toBeLessThan(400)
 		})
 
-		// As of Bun 1.3.1, Bun's `SQL` pending query `.cancel()` doesn't
-		// actually cancel the in-flight query server-side (see the
-		// `PostgresJSPendingQuery.cancel` doc comment in dialect-config.mts),
-		// so the update below completes instead of being aborted.
 		it.skipIf(dialect === 'bun')(
 			"should cancel the query on the database side when inflightQueryAbortStrategy is 'cancel query'",
 			async () => {
@@ -315,6 +319,50 @@ for (const dialect of SUPPORTED_DIALECTS) {
 			},
 		)
 
+		it.skipIf(dialect !== 'bun')(
+			"should throw, in the background, instead of silently no-op-ing when inflightQueryAbortStrategy is 'cancel query'",
+			async () => {
+				const consoleErrorSpy = vi
+					.spyOn(console, 'error')
+					.mockImplementation(() => {})
+
+				await expect(
+					sql`update person set name = 'cancelled' from (select pg_sleep(0.5)) as delay where name = 'moshe'`.execute(
+						ctx.db,
+						{
+							signal: AbortSignal.timeout(50),
+							inflightQueryAbortStrategy: 'cancel query',
+						},
+					),
+				).rejects.toThrow()
+
+				// the background inflight-query-abort-handler failure is only
+				// reported asynchronously, after the execute() call above
+				// already rejected due to the abort signal.
+				await sleep(100)
+
+				expect(consoleErrorSpy).toHaveBeenCalledWith(
+					expect.stringContaining(
+						'Cancelling in-flight queries is not supported when running on Bun',
+					),
+				)
+
+				consoleErrorSpy.mockRestore()
+
+				// give the sleep plenty of time to finish, since Bun can't
+				// actually cancel it on the database side.
+				await sleep(700)
+
+				const person = await ctx.db
+					.selectFrom('person')
+					.select('name')
+					.where('id', '=', '48856ed4-9f1f-4111-ba7f-6092a1be96eb')
+					.executeTakeFirstOrThrow()
+
+				expect(person.name).toBe('cancelled')
+			},
+		)
+
 		it.skipIf(dialect === 'bun')(
 			'should stream normally when passed a non-aborted signal',
 			async () => {
@@ -333,7 +381,7 @@ for (const dialect of SUPPORTED_DIALECTS) {
 			},
 		)
 
-		it.skipIf(dialect === 'bun')(
+		it(
 			'should reject immediately when streaming with an already aborted signal',
 			async () => {
 				const controller = new AbortController()

--- a/tests/crud.test.mts
+++ b/tests/crud.test.mts
@@ -1,3 +1,4 @@
+import { sql } from 'kysely'
 import { isBun } from 'std-env'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import {
@@ -6,6 +7,9 @@ import {
 	SUPPORTED_DIALECTS,
 	type TestContext,
 } from './test-setup.mjs'
+
+const sleep = (ms: number): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, ms))
 
 for (const dialect of SUPPORTED_DIALECTS) {
 	describe.skipIf(dialect === 'bun' && !isBun)(dialect, () => {
@@ -243,6 +247,105 @@ for (const dialect of SUPPORTED_DIALECTS) {
 						  },
 						]
 					`)
+			},
+		)
+
+		it('should execute normally when passed a non-aborted signal', async () => {
+			const result = await ctx.db
+				.selectFrom('person')
+				.selectAll()
+				.execute({ signal: new AbortController().signal })
+
+			expect(result).toHaveLength(4)
+		})
+
+		it('should reject immediately when the signal is already aborted', async () => {
+			const controller = new AbortController()
+			const reason = new Error('aborted before execution')
+			controller.abort(reason)
+
+			await expect(
+				ctx.db
+					.selectFrom('person')
+					.selectAll()
+					.execute({ signal: controller.signal }),
+			).rejects.toBe(reason)
+		})
+
+		it('should abort a slow query promptly instead of waiting for it to finish', async () => {
+			const start = Date.now()
+
+			await expect(
+				sql`select pg_sleep(0.5)`.execute(ctx.db, {
+					signal: AbortSignal.timeout(50),
+				}),
+			).rejects.toThrow()
+
+			expect(Date.now() - start).toBeLessThan(400)
+		})
+
+		// As of Bun 1.3.1, Bun's `SQL` pending query `.cancel()` doesn't
+		// actually cancel the in-flight query server-side (see the
+		// `PostgresJSPendingQuery.cancel` doc comment in dialect-config.mts),
+		// so the update below completes instead of being aborted.
+		it.skipIf(dialect === 'bun')(
+			"should cancel the query on the database side when inflightQueryAbortStrategy is 'cancel query'",
+			async () => {
+				await expect(
+					sql`update person set name = 'cancelled' from (select pg_sleep(0.5)) as delay where name = 'moshe'`.execute(
+						ctx.db,
+						{
+							signal: AbortSignal.timeout(50),
+							inflightQueryAbortStrategy: 'cancel query',
+						},
+					),
+				).rejects.toThrow()
+
+				// give the sleep plenty of time to finish, in case the update
+				// wasn't actually cancelled on the database side.
+				await sleep(700)
+
+				const person = await ctx.db
+					.selectFrom('person')
+					.select('name')
+					.where('id', '=', '48856ed4-9f1f-4111-ba7f-6092a1be96eb')
+					.executeTakeFirstOrThrow()
+
+				expect(person.name).toBe('moshe')
+			},
+		)
+
+		it.skipIf(dialect === 'bun')(
+			'should stream normally when passed a non-aborted signal',
+			async () => {
+				const items = []
+
+				const iterator = ctx.db
+					.selectFrom('person')
+					.selectAll()
+					.stream({ signal: new AbortController().signal })
+
+				for await (const item of iterator) {
+					items.push(item)
+				}
+
+				expect(items).toHaveLength(4)
+			},
+		)
+
+		it.skipIf(dialect === 'bun')(
+			'should reject immediately when streaming with an already aborted signal',
+			async () => {
+				const controller = new AbortController()
+				const reason = new Error('aborted before streaming')
+				controller.abort(reason)
+
+				const iterator = ctx.db
+					.selectFrom('person')
+					.selectAll()
+					.stream({ signal: controller.signal })
+
+				await expect(iterator.next()).rejects.toBe(reason)
 			},
 		)
 	})

--- a/tests/crud.test.mts
+++ b/tests/crud.test.mts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises'
 import { sql } from 'kysely'
 import { isBun } from 'std-env'
 import {
@@ -15,9 +16,6 @@ import {
 	SUPPORTED_DIALECTS,
 	type TestContext,
 } from './test-setup.mjs'
-
-const sleep = (ms: number): Promise<void> =>
-	new Promise((resolve) => setTimeout(resolve, ms))
 
 for (const dialect of SUPPORTED_DIALECTS) {
 	describe.skipIf(dialect === 'bun' && !isBun)(dialect, () => {
@@ -307,7 +305,7 @@ for (const dialect of SUPPORTED_DIALECTS) {
 
 				// give the sleep plenty of time to finish, in case the update
 				// wasn't actually cancelled on the database side.
-				await sleep(700)
+				await setTimeout(700)
 
 				const person = await ctx.db
 					.selectFrom('person')
@@ -339,7 +337,7 @@ for (const dialect of SUPPORTED_DIALECTS) {
 				// the background inflight-query-abort-handler failure is only
 				// reported asynchronously, after the execute() call above
 				// already rejected due to the abort signal.
-				await sleep(100)
+				await setTimeout(100)
 
 				expect(consoleErrorSpy).toHaveBeenCalledWith(
 					expect.stringContaining(
@@ -351,7 +349,7 @@ for (const dialect of SUPPORTED_DIALECTS) {
 
 				// give the sleep plenty of time to finish, since Bun can't
 				// actually cancel it on the database side.
-				await sleep(700)
+				await setTimeout(700)
 
 				const person = await ctx.db
 					.selectFrom('person')


### PR DESCRIPTION
Adding the `cancelQuery` implementation to this dialect, following up the addition to the PostgresDialect in https://github.com/kysely-org/kysely/pull/1796.

It was nicely pretty trivial since the `postgres` driver already has a cancel method on queries.

Notably does not include the `killSession` method. There wasn't a deterministic way to wait on the connection to be killed. The pool would mark it as open before the socket would fully close, so the next query routed to it would fail withe `write CONNECTION_CLOSED`. Even with a delay, that then caused a different error with trying to call `write` on the null socket.