### PR TITLE
feat: support `cancel query` in Bun, support `kill session`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,82 @@ const db = new Kysely<Database>({
 
 const people = await db.selectFrom("person").selectAll().execute();
 ```
+
+## Aborting queries
+
+This dialect supports Kysely's `AbortSignal` integration, including the
+`'cancel query'` and `'kill session'` values of `inflightQueryAbortStrategy`,
+which stop the aborted query on the database side:
+
+```ts
+await db
+  .selectFrom('person')
+  .selectAll()
+  .execute({
+    signal: AbortSignal.timeout(5_000),
+    inflightQueryAbortStrategy: 'kill session',
+  })
+```
+
+Under the hood, `'cancel query'` uses [Postgres.js](https://github.com/porsager/postgres)'
+native wire-protocol cancellation when running on [Postgres.js](https://github.com/porsager/postgres),
+and `pg_cancel_backend` on a control connection when running on [Bun](https://bun.com/)'s
+[SQL](https://bun.com/docs/api/sql) (whose `cancel()` doesn't cancel queries on
+the database side). `'kill session'` executes `pg_terminate_backend` on a
+control connection in both cases.
+
+### `controlPostgres`
+
+By default, control queries (e.g. `pg_terminate_backend`) are executed on a
+connection acquired from the `postgres` pool. This might mean waiting for an
+idle connection, and with a small, saturated pool (e.g. `max: 1`), it can wait
+forever - the aborted query's connection is only returned to the pool after
+the control query runs.
+
+To avoid this, provide `controlPostgres`. You can pass `postgres` or Bun's
+`SQL` directly - it is invoked with the main instance's resolved options, with
+`max` overridden to `1`. A custom factory receiving those options works too.
+Both libraries' pools are lazy, so the control instance doesn't hold a
+connection until the first control query runs.
+
+#### Node.js
+
+```ts
+import { Kysely } from 'kysely'
+import { PostgresJSDialect } from 'kysely-postgres-js'
+import postgres from 'postgres'
+
+const db = new Kysely<Database>({
+  dialect: new PostgresJSDialect({
+    controlPostgres: postgres,
+    postgres: postgres({
+      database: 'test',
+      host: 'localhost',
+      max: 10,
+      port: 5434,
+      user: 'admin',
+    }),
+  }),
+})
+```
+
+#### Bun
+
+```ts
+import { SQL } from 'bun'
+import { Kysely } from 'kysely'
+import { PostgresJSDialect } from 'kysely-postgres-js'
+
+const db = new Kysely<Database>({
+  dialect: new PostgresJSDialect({
+    controlPostgres: SQL,
+    postgres: new SQL({
+      database: 'test',
+      host: 'localhost',
+      max: 10,
+      port: 5434,
+      user: 'admin',
+    }),
+  }),
+})
+```

--- a/src/dialect-config.ts
+++ b/src/dialect-config.ts
@@ -2,6 +2,28 @@ import type { AbortableOperationOptions, DatabaseConnection } from 'kysely'
 
 export interface PostgresJSDialectConfig {
 	/**
+	 * A factory returning an instance of `postgres`'s `Sql` (returned by
+	 * `postgres(...)`) or Bun's `SQL` class, to be used for connecting to the
+	 * database outside of {@link postgres | `postgres`}'s pool to avoid waiting
+	 * for an idle connection. You can pass `postgres` or `SQL` directly - both
+	 * work when called without `new`.
+	 *
+	 * Control queries (e.g. `pg_cancel_backend`) are executed through it when
+	 * using Kysely's `inflightQueryAbortStrategy`. The factory receives the
+	 * main instance's resolved options, with `max` set to `1` - construct the
+	 * control instance with the same library that created the main instance.
+	 * Since both libraries' pools are lazy, the returned instance doesn't hold
+	 * a connection until the first control query runs.
+	 *
+	 * When not provided, control queries are executed on a connection acquired
+	 * from {@link postgres | `postgres`}'s pool, which might mean waiting for
+	 * an idle connection.
+	 */
+	controlPostgres?:
+		| ((options: PostgresJSSql['options']) => PostgresJSSql)
+		| BunSqlClass
+
+	/**
 	 * Called every time a connection is acquired from the pool.
 	 */
 	onReserveConnection?: (
@@ -20,8 +42,23 @@ export interface PostgresJSDialectConfig {
 }
 
 export interface PostgresJSSql {
-	end(): Promise<void>
+	end(options?: { timeout?: number }): Promise<void>
+
+	options: PostgresJSSqlOptions
+
 	reserve(): Promise<PostgresJSReservedSql>
+}
+
+export interface PostgresJSSqlOptions {
+	/**
+	 * Bun SQL only.
+	 */
+	adapter?: 'postgres' | 'mysql' | 'sqlite' | 'mariadb'
+	max?: number
+}
+
+export interface BunSqlClass {
+	new (options?: PostgresJSSqlOptions): PostgresJSSql
 }
 
 export interface PostgresJSReservedSql {
@@ -40,16 +77,30 @@ export interface PostgresJSPendingQuery
 	extends Promise<any[] & Iterable<any> & PostgresJSResultQueryMeta> {
 	/**
 	 * Cancels this pending query on the database side, if supported. Present on
-	 * both `postgres`'s pending queries and Bun's `SQL`, though Bun
-	 * `SQL`'s pending query `.cancel()` doesn't actually cancel the in-flight
-	 * query server-side. Because of that, `PostgresJSConnection.cancelQuery`
-	 * throws instead of calling this when running on Bun, rather than being a no-op.
+	 * both `postgres`'s pending queries and Bun's `SQL`, though Bun `SQL`'s
+	 * pending query `.cancel()` is a client-side placeholder - it only flips
+	 * the query's `cancelled` flag, without cancelling the in-flight query
+	 * server-side (the query even resolves normally). Because of that,
+	 * `PostgresJSConnection.cancelQuery` only calls this when running on
+	 * `postgres`, and cancels on the database side itself when running on Bun,
+	 * by executing `pg_cancel_backend` on a control connection - similarly to
+	 * Kysely's core dialects.
 	 */
-	cancel?: () => void
+	cancel: () => void
+
 	// biome-ignore lint/suspicious/noExplicitAny: we wanna match widely, to be safe.
 	cursor?: (rows?: number) => AsyncIterable<any[]>
 	// | ((rows: number, cb: (rows: any[]) => void) => Promise<ExecutionResult>)
 	// | ((cb: (row: [any]) => void) => Promise<ExecutionResult>)
+
+	/**
+	 * This is the state of the connection that executed the query.
+	 *
+	 * Exists only in `postgres`.
+	 */
+	state?: {
+		pid: number
+	}
 }
 
 interface PostgresJSResultQueryMeta {

--- a/src/dialect-config.ts
+++ b/src/dialect-config.ts
@@ -51,7 +51,7 @@ export interface PostgresJSSql {
 
 export interface PostgresJSSqlOptions {
 	/**
-	 * Bun SQL only.
+	 * Bun.SQL only.
 	 */
 	adapter?: 'postgres' | 'mysql' | 'sqlite' | 'mariadb'
 	max?: number
@@ -75,17 +75,6 @@ export interface PostgresJSReservedSql {
 export interface PostgresJSPendingQuery
 	// biome-ignore lint/suspicious/noExplicitAny: we wanna match widely, to be safe.
 	extends Promise<any[] & Iterable<any> & PostgresJSResultQueryMeta> {
-	/**
-	 * Cancels this pending query on the database side, if supported. Present on
-	 * both `postgres`'s pending queries and Bun's `SQL`, though Bun `SQL`'s
-	 * pending query `.cancel()` is a client-side placeholder - it only flips
-	 * the query's `cancelled` flag, without cancelling the in-flight query
-	 * server-side (the query even resolves normally). Because of that,
-	 * `PostgresJSConnection.cancelQuery` only calls this when running on
-	 * `postgres`, and cancels on the database side itself when running on Bun,
-	 * by executing `pg_cancel_backend` on a control connection - similarly to
-	 * Kysely's core dialects.
-	 */
 	cancel: () => void
 
 	// biome-ignore lint/suspicious/noExplicitAny: we wanna match widely, to be safe.
@@ -94,9 +83,7 @@ export interface PostgresJSPendingQuery
 	// | ((cb: (row: [any]) => void) => Promise<ExecutionResult>)
 
 	/**
-	 * This is the state of the connection that executed the query.
-	 *
-	 * Exists only in `postgres`.
+	 * `postgres` only.
 	 */
 	state?: {
 		pid: number

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -296,7 +296,7 @@ class PostgresJSConnection implements DatabaseConnection {
 		action: 'cancel' | 'terminate',
 		controlConnectionProvider: ControlConnectionProvider,
 	): Promise<void> {
-		if (!this.#pid) {
+		if (this.#pid == null) {
 			throw new PostgresJSDialectError('pid missing for backend query')
 		}
 
@@ -312,12 +312,14 @@ class PostgresJSConnection implements DatabaseConnection {
 
 		if (!this.#controlPostgres) {
 			return await controlConnectionProvider(async (connection) => {
-				if (this.#pendingQuery === pendingQuery) {
-					await connection.executeQuery(CompiledQuery.raw(query))
+				if (this.#pendingQuery !== pendingQuery) {
+					return
+				}
 
-					if (action === 'terminate') {
-						this.#sessionKilled = true
-					}
+				await connection.executeQuery(CompiledQuery.raw(query))
+
+				if (action === 'terminate') {
+					this.#sessionKilled = true
 				}
 			})
 		}
@@ -325,12 +327,14 @@ class PostgresJSConnection implements DatabaseConnection {
 		const controlConnection = await this.#controlPostgres.reserve()
 
 		try {
-			if (this.#pendingQuery === pendingQuery) {
-				await controlConnection.unsafe(query)
+			if (this.#pendingQuery !== pendingQuery) {
+				return
+			}
 
-				if (action === 'terminate') {
-					this.#sessionKilled = true
-				}
+			await controlConnection.unsafe(query)
+
+			if (action === 'terminate') {
+				this.#sessionKilled = true
 			}
 		} finally {
 			controlConnection.release()

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -1,23 +1,30 @@
 import {
 	type AbortableOperationOptions,
-	type CompiledQuery,
+	CompiledQuery,
+	type ControlConnectionProvider,
 	type DatabaseConnection,
 	PostgresDriver,
 	type QueryResult,
 } from 'kysely'
 import type {
+	BunSqlClass,
 	PostgresJSDialectConfig,
 	PostgresJSPendingQuery,
 	PostgresJSReservedSql,
 	PostgresJSSql,
+	PostgresJSSqlOptions,
 } from './dialect-config.js'
 import { freeze } from './utils.js'
 
 const RELEASE_CONNECTION_SYMBOL = Symbol('release')
+const SESSION_KILLED_SYMBOL = Symbol('sessionKilled')
 
 export class PostgresJSDriver extends PostgresDriver {
 	readonly #config: PostgresJSDialectConfig
+	#controlPostgres: PostgresJSSql | undefined
+	#isBun: boolean | undefined
 	#postgres: PostgresJSSql | undefined
+	#sessionsKilled = false
 
 	constructor(config: PostgresJSDialectConfig) {
 		super({} as never)
@@ -27,10 +34,17 @@ export class PostgresJSDriver extends PostgresDriver {
 	override async acquireConnection(
 		options?: AbortableOperationOptions,
 	): Promise<PostgresJSConnection> {
-		// biome-ignore lint/style/noNonNullAssertion: `init` ran at this point.
-		const reservedConnection = await this.#postgres!.reserve()
+		if (!this.#postgres) {
+			throw new PostgresJSDialectError('missing underlying driver instance')
+		}
 
-		const connection = new PostgresJSConnection(reservedConnection)
+		const reservedConnection = await this.#postgres.reserve()
+
+		const connection = new PostgresJSConnection(
+			reservedConnection,
+			this.#isBun,
+			this.#controlPostgres,
+		)
 
 		await this.#config.onReserveConnection?.(connection, options)
 
@@ -38,23 +52,77 @@ export class PostgresJSDriver extends PostgresDriver {
 	}
 
 	override async destroy(_options?: AbortableOperationOptions): Promise<void> {
-		// biome-ignore lint/style/noNonNullAssertion: `init` ran at this point.
-		await this.#postgres!.end()
+		// Bun SQL's pool cannot gracefully `end()` once a reserved connection's
+		// session was killed via `pg_terminate_backend` - even when the killed
+		// query settled cleanly beforehand - so we have to force-close.
+		// `postgres` is unaffected: `killSession` cancels the in-flight query
+		// first, so its pool stays cleanly endable.
+		const endOptions =
+			this.#isBun && this.#sessionsKilled ? { timeout: 0 } : undefined
+
+		await Promise.all([
+			this.#postgres?.end(endOptions),
+			this.#controlPostgres?.end(endOptions),
+		])
 	}
 
 	override async init(options?: AbortableOperationOptions): Promise<void> {
-		const { postgres } = this.#config
+		const { controlPostgres, postgres } = this.#config
 
-		this.#postgres = isPostgresJSSql(postgres)
+		const instance = isPostgresJSSql(postgres)
 			? postgres
 			: await postgres(options)
+
+		this.#postgres = this.#assertPostgres(instance)
+
+		if (!controlPostgres) {
+			return
+		}
+
+		const controlOptions = { ...this.#postgres.options, max: 1 }
+
+		this.#controlPostgres = (controlPostgres as { prototype?: unknown })
+			.prototype
+			? new (controlPostgres as BunSqlClass)(controlOptions)
+			: (controlPostgres as (options: PostgresJSSqlOptions) => PostgresJSSql)(
+					controlOptions,
+				)
 	}
 
 	override async releaseConnection(
 		connection: DatabaseConnection,
 		_options?: AbortableOperationOptions,
 	): Promise<void> {
+		this.#sessionsKilled ||= (connection as PostgresJSConnection)[
+			SESSION_KILLED_SYMBOL
+		]
 		;(connection as PostgresJSConnection)[RELEASE_CONNECTION_SYMBOL]()
+	}
+
+	#assertPostgres(sql: PostgresJSSql): PostgresJSSql {
+		if (typeof Bun === 'undefined') {
+			this.#isBun = false
+
+			return sql
+		}
+
+		const { adapter } = sql.options || {}
+
+		if (!adapter) {
+			this.#isBun = false
+
+			return sql
+		}
+
+		if (adapter !== 'postgres') {
+			throw new PostgresJSDialectError(
+				`PostgresJSDialect only supports Bun SQL's PostgreSQL adapter, but the instance you passed to it resolved to the "${adapter}" adapter.`,
+			)
+		}
+
+		this.#isBun = true
+
+		return sql
 	}
 }
 
@@ -62,34 +130,54 @@ function isPostgresJSSql(thing: unknown): thing is PostgresJSSql {
 	return typeof thing === 'function' && 'reserve' in thing
 }
 
-function isBunSql(thing: unknown): boolean {
-	return (
-		typeof thing === 'function' &&
-		// biome-ignore lint/suspicious/noExplicitAny: we wanna match widely, to be safe.
-		typeof (thing as any).options?.adapter === 'string'
-	)
-}
-
 class PostgresJSConnection implements DatabaseConnection {
+	readonly #controlPostgres: PostgresJSSql | undefined
+	readonly #isBun: boolean | undefined
 	readonly #reservedConnection: PostgresJSReservedSql
 	#pendingQuery: PostgresJSPendingQuery | undefined
+	#pid: number | undefined
+	#sessionKilled = false
 
-	constructor(reservedConnection: PostgresJSReservedSql) {
+	constructor(
+		reservedConnection: PostgresJSReservedSql,
+		isBun: boolean | undefined,
+		controlPostgres: PostgresJSSql | undefined,
+	) {
+		this.#controlPostgres = controlPostgres
+		this.#isBun = isBun
 		this.#reservedConnection = reservedConnection
 	}
 
-	async cancelQuery(): Promise<void> {
+	get [SESSION_KILLED_SYMBOL](): boolean {
+		return this.#sessionKilled
+	}
+
+	async cancelQuery(
+		controlConnectionProvider: ControlConnectionProvider,
+	): Promise<void> {
+		// Bun SQL's `cancel` is a placeholder right now.
+		if (!this.#isBun) {
+			return this.#pendingQuery?.cancel()
+		}
+
 		if (!this.#pendingQuery) {
 			return
 		}
 
-		if (isBunSql(this.#reservedConnection)) {
-			throw new PostgresJSDialectError(
-				"Cancelling in-flight queries is not supported when running on Bun. Bun's `SQL` pending query `.cancel()` does not actually cancel the query on the database side.",
-			)
+		return await this.#affectBackend('cancel', controlConnectionProvider)
+	}
+
+	async collectSessionInfo(): Promise<void> {
+		// postgres.js hands us the pid on pending queries.
+		if (this.#pid != null || !this.#isBun) {
+			return
 		}
 
-		this.#pendingQuery.cancel?.()
+		const [{ pid }] = await this.#reservedConnection.unsafe(
+			'select pg_backend_pid() as pid',
+		)
+
+		this.#pid = pid
 	}
 
 	async executeQuery<R>(
@@ -119,10 +207,71 @@ class PostgresJSConnection implements DatabaseConnection {
 		}
 	}
 
+	async killSession(
+		controlConnectionProvider: ControlConnectionProvider,
+	): Promise<void> {
+		if (this.#isBun) {
+			if (!this.#pendingQuery) {
+				return
+			}
+
+			return await this.#affectBackend('terminate', controlConnectionProvider)
+		}
+
+		// captured once - the field is cleared by `executeQuery`'s `finally` the
+		// moment the query settles, while we keep needing the promise below.
+		const pendingQuery = this.#pendingQuery
+
+		if (!pendingQuery) {
+			return
+		}
+
+		this.#pid ??= pendingQuery.state?.pid
+
+		// terminating a busy `postgres` connection poisons its pool slot - the
+		// in-flight query's state is never cleared on socket close, so the slot
+		// can never reconnect and graceful `end()` hangs forever. cancelling
+		// first lets the connection settle cleanly, and only then we terminate
+		// the idle session.
+		pendingQuery.cancel()
+
+		// `cancel()` only *requests* cancellation - it fires a CancelRequest
+		// over a separate throwaway socket, while the reserved connection's
+		// internal in-flight query state is only cleared once the server's
+		// response ("57014: canceling statement due to user request", which is
+		// not ours to throw) arrives back on the data socket. the promise
+		// settling is the one observable signal that this round trip completed
+		// and the connection is idle and clean. terminating without waiting
+		// races the two sockets - if `pg_terminate_backend` wins, the backend
+		// dies mid-statement, and we've poisoned the slot after all.
+		const wasCancelled = await pendingQuery.then(
+			() => false,
+			(error) => (error as { code?: unknown } | null)?.code === '57014',
+		)
+
+		// the query settled without our cancellation interrupting it - it either
+		// beat the cancel and completed successfully, or failed on its own.
+		// Kysely's core dialects don't kill the session once the query settled -
+		// neither do we.
+		if (!wasCancelled) {
+			return
+		}
+
+		return await this.#affectBackend('terminate', controlConnectionProvider)
+	}
+
 	async *streamQuery<R>(
 		compiledQuery: CompiledQuery<unknown>,
 		chunkSize: number,
 	): AsyncIterableIterator<QueryResult<R>> {
+		// prefer we don't allow bun here to avoid surprises if and when
+		// they add the cursor function.
+		if (this.#isBun) {
+			throw new PostgresJSDialectError(
+				'streaming queries is not supported in Bun.SQL',
+			)
+		}
+
 		if (!Number.isInteger(chunkSize) || chunkSize <= 0) {
 			throw new PostgresJSDialectError('chunkSize must be a positive integer')
 		}
@@ -131,14 +280,8 @@ class PostgresJSConnection implements DatabaseConnection {
 			...compiledQuery.parameters,
 		])
 
-		if (typeof this.#pendingQuery.cursor !== 'function') {
-			this.#pendingQuery = undefined
-			throw new Error(
-				'PostgresJSDialect detected the instance you passed to it does not support streaming.',
-			)
-		}
-
-		const cursor = this.#pendingQuery.cursor(chunkSize)
+		// biome-ignore lint/style/noNonNullAssertion: only Bun SQL lacks `cursor`, and we threw for Bun above.
+		const cursor = this.#pendingQuery.cursor!(chunkSize)
 
 		try {
 			for await (const rows of cursor) {
@@ -149,7 +292,59 @@ class PostgresJSConnection implements DatabaseConnection {
 		}
 	}
 
+	async #affectBackend(
+		action: 'cancel' | 'terminate',
+		controlConnectionProvider: ControlConnectionProvider,
+	): Promise<void> {
+		if (!this.#pid) {
+			throw new PostgresJSDialectError('pid missing for backend query')
+		}
+
+		// the pending query as of this moment. the control query is only fired
+		// if this hasn't changed by the time we hold a control connection - a
+		// change means another query took over the reserved connection. in
+		// `postgres`'s kill flow this is already `undefined` - we settled the
+		// query ourselves via cancel - and "still no pending query" passes the
+		// same check.
+		const pendingQuery = this.#pendingQuery
+
+		const query = `select pg_${action}_backend(${this.#pid})`
+
+		if (!this.#controlPostgres) {
+			return await controlConnectionProvider(async (connection) => {
+				if (this.#pendingQuery === pendingQuery) {
+					await connection.executeQuery(CompiledQuery.raw(query))
+
+					if (action === 'terminate') {
+						this.#sessionKilled = true
+					}
+				}
+			})
+		}
+
+		const controlConnection = await this.#controlPostgres.reserve()
+
+		try {
+			if (this.#pendingQuery === pendingQuery) {
+				await controlConnection.unsafe(query)
+
+				if (action === 'terminate') {
+					this.#sessionKilled = true
+				}
+			}
+		} finally {
+			controlConnection.release()
+		}
+	}
+
 	[RELEASE_CONNECTION_SYMBOL](): void {
+		// after `pg_terminate_backend`, `postgres`'s pool has already moved the
+		// dead connection to its closed queue. releasing it would move it back
+		// to the open queue, and queries dispatched to it would then hang.
+		if (this.#sessionKilled && !this.#isBun) {
+			return
+		}
+
 		this.#reservedConnection.release()
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
 /** biome-ignore-all lint/performance/noBarrelFile: we're in library context and need an entry point */
 export { PostgresJSDialect } from './dialect.js'
-export type { PostgresJSDialectConfig } from './dialect-config.js'
+export type {
+	PostgresJSDialectConfig,
+	PostgresJSPendingQuery,
+	PostgresJSReservedSql,
+	PostgresJSSql,
+	PostgresJSSqlOptions,
+} from './dialect-config.js'
 export {
 	PostgresJSDialectError,
 	PostgresJSDriver,

--- a/tests/crud.test.ts
+++ b/tests/crud.test.ts
@@ -1,5 +1,6 @@
 import { setTimeout } from 'node:timers/promises'
-import { sql } from 'kysely'
+import { Kysely, sql } from 'kysely'
+import postgres from 'postgres'
 import { isBun } from 'std-env'
 import {
 	afterAll,
@@ -10,7 +11,10 @@ import {
 	it,
 	vi,
 } from 'vitest'
+import { PostgresJSDialect, type PostgresJSSql } from '..'
 import {
+	CONNECTION_STRING,
+	type Database,
 	initTest,
 	resetState,
 	SUPPORTED_DIALECTS,
@@ -292,15 +296,116 @@ for (const dialect of SUPPORTED_DIALECTS) {
 			expect(Date.now() - start).toBeLessThan(400)
 		})
 
-		it.skipIf(dialect === 'bun')(
-			"should cancel the query on the database side when inflightQueryAbortStrategy is 'cancel query'",
-			async () => {
+		it("should cancel the query on the database side when inflightQueryAbortStrategy is 'cancel query'", async () => {
+			await expect(
+				sql`update person set name = 'cancelled' from (select pg_sleep(0.5)) as delay where name = 'moshe'`.execute(
+					ctx.db,
+					{
+						signal: timeoutSignal(50),
+						inflightQueryAbortStrategy: 'cancel query',
+					},
+				),
+			).rejects.toSatisfy((error) => {
+				expect(error).toBeInstanceOf(DOMException)
+				expect(error).toMatchObject({
+					name: 'TimeoutError',
+					__kysely_timing__: 'during query execution',
+				})
+				return true
+			})
+
+			// give the sleep plenty of time to finish, in case the update
+			// wasn't actually cancelled on the database side.
+			await setTimeout(700)
+
+			const person = await ctx.db
+				.selectFrom('person')
+				.select('name')
+				.where('id', '=', '48856ed4-9f1f-4111-ba7f-6092a1be96eb')
+				.executeTakeFirstOrThrow()
+
+			expect(person.name).toBe('moshe')
+		})
+
+		it("should kill the session on the database side when inflightQueryAbortStrategy is 'kill session'", async () => {
+			// the killed query rejects in the background with a connection
+			// error, which kysely reports via console.error.
+			vi.spyOn(console, 'error').mockImplementation(() => {})
+
+			await expect(
+				sql`update person set name = 'killed' from (select pg_sleep(0.5)) as delay where name = 'moshe'`.execute(
+					ctx.db,
+					{
+						signal: timeoutSignal(50),
+						inflightQueryAbortStrategy: 'kill session',
+					},
+				),
+			).rejects.toSatisfy((error) => {
+				expect(error).toBeInstanceOf(DOMException)
+				expect(error).toMatchObject({
+					name: 'TimeoutError',
+					__kysely_timing__: 'during query execution',
+				})
+				return true
+			})
+
+			// give the sleep plenty of time to finish, in case the session
+			// wasn't actually terminated on the database side.
+			await setTimeout(700)
+
+			const person = await ctx.db
+				.selectFrom('person')
+				.select('name')
+				.where('id', '=', '48856ed4-9f1f-4111-ba7f-6092a1be96eb')
+				.executeTakeFirstOrThrow()
+
+			expect(person.name).toBe('moshe')
+
+			// the pool should replace the terminated connection transparently.
+			const people = await ctx.db.selectFrom('person').selectAll().execute()
+
+			expect(people).toHaveLength(4)
+		})
+
+		it("should kill the session through `controlPostgres` when it is configured and inflightQueryAbortStrategy is 'kill session'", async () => {
+			// the killed query rejects in the background with a connection
+			// error, which kysely reports via console.error.
+			vi.spyOn(console, 'error').mockImplementation(() => {})
+
+			const controlQueries: string[] = []
+
+			const { db } = await initTest(dialect, {
+				controlPostgres: (options) => {
+					const instance: PostgresJSSql =
+						dialect === 'bun'
+							? new Bun.SQL(options)
+							: (postgres(options as never) as unknown as PostgresJSSql)
+
+					return {
+						end: () => instance.end(),
+						options: instance.options,
+						reserve: async () => {
+							const reservedConnection = await instance.reserve()
+
+							return {
+								release: () => reservedConnection.release(),
+								unsafe: (query, ...args) => {
+									controlQueries.push(query)
+									return reservedConnection.unsafe(query, ...args)
+								},
+							}
+						},
+					}
+				},
+			})
+
+			try {
 				await expect(
-					sql`update person set name = 'cancelled' from (select pg_sleep(0.5)) as delay where name = 'moshe'`.execute(
-						ctx.db,
+					sql`update person set name = 'killed' from (select pg_sleep(0.5)) as delay where name = 'moshe'`.execute(
+						db,
 						{
 							signal: timeoutSignal(50),
-							inflightQueryAbortStrategy: 'cancel query',
+							inflightQueryAbortStrategy: 'kill session',
 						},
 					),
 				).rejects.toSatisfy((error) => {
@@ -312,70 +417,75 @@ for (const dialect of SUPPORTED_DIALECTS) {
 					return true
 				})
 
-				// give the sleep plenty of time to finish, in case the update
-				// wasn't actually cancelled on the database side.
-				await setTimeout(700)
+				await setTimeout(100)
 
-				const person = await ctx.db
+				expect(controlQueries).toContainEqual(
+					expect.stringContaining('pg_terminate_backend'),
+				)
+
+				await setTimeout(600)
+
+				const person = await db
 					.selectFrom('person')
 					.select('name')
 					.where('id', '=', '48856ed4-9f1f-4111-ba7f-6092a1be96eb')
 					.executeTakeFirstOrThrow()
 
 				expect(person.name).toBe('moshe')
-			},
-		)
+			} finally {
+				await db.destroy()
+			}
+		})
 
-		it.skipIf(dialect !== 'bun')(
-			"should throw, in the background, instead of silently no-op-ing when inflightQueryAbortStrategy is 'cancel query'",
-			async () => {
-				const consoleErrorSpy = vi
-					.spyOn(console, 'error')
-					.mockImplementation(() => {})
+		it("should not leak the main pool's only slot when killing sessions", async () => {
+			// the killed query rejects in the background with a connection
+			// error, which kysely reports via console.error.
+			vi.spyOn(console, 'error').mockImplementation(() => {})
 
+			const db = new Kysely<Database>({
+				dialect: new PostgresJSDialect({
+					controlPostgres: dialect === 'bun' ? Bun.SQL : postgres,
+					postgres: () =>
+						dialect === 'bun'
+							? import('bun').then(
+									(mod) =>
+										new mod.SQL(CONNECTION_STRING, {
+											max: 1,
+										}) as unknown as PostgresJSSql,
+								)
+							: (postgres(CONNECTION_STRING, {
+									max: 1,
+									onnotice() {},
+								}) as unknown as PostgresJSSql),
+				}),
+			})
+
+			try {
 				await expect(
-					sql`update person set name = 'cancelled' from (select pg_sleep(0.5)) as delay where name = 'moshe'`.execute(
-						ctx.db,
-						{
-							signal: timeoutSignal(50),
-							inflightQueryAbortStrategy: 'cancel query',
-						},
-					),
+					sql`select pg_sleep(0.5)`.execute(db, {
+						signal: timeoutSignal(50),
+						inflightQueryAbortStrategy: 'kill session',
+					}),
 				).rejects.toSatisfy((error) => {
 					expect(error).toBeInstanceOf(DOMException)
 					expect(error).toMatchObject({
 						name: 'TimeoutError',
-						message: 'The operation timed out.',
+						__kysely_timing__: 'during query execution',
 					})
 					return true
 				})
 
-				// the background inflight-query-abort-handler failure is only
-				// reported asynchronously, after the execute() call above
-				// already rejected due to the abort signal.
-				await setTimeout(100)
+				await setTimeout(300)
 
-				expect(consoleErrorSpy).toHaveBeenCalledWith(
-					expect.stringContaining(
-						'Cancelling in-flight queries is not supported when running on Bun',
-					),
-				)
+				// the pool's only slot held the killed session. subsequent
+				// queries must get a fresh connection in its place.
+				const people = await db.selectFrom('person').selectAll().execute()
 
-				consoleErrorSpy.mockRestore()
-
-				// give the sleep plenty of time to finish, since Bun can't
-				// actually cancel it on the database side.
-				await setTimeout(700)
-
-				const person = await ctx.db
-					.selectFrom('person')
-					.select('name')
-					.where('id', '=', '48856ed4-9f1f-4111-ba7f-6092a1be96eb')
-					.executeTakeFirstOrThrow()
-
-				expect(person.name).toBe('cancelled')
-			},
-		)
+				expect(people).toHaveLength(4)
+			} finally {
+				await db.destroy()
+			}
+		})
 
 		it.skipIf(dialect === 'bun')(
 			'should stream normally when passed a non-aborted signal',

--- a/tests/dialect.test.ts
+++ b/tests/dialect.test.ts
@@ -1,0 +1,23 @@
+import { Kysely, sql } from 'kysely'
+import { isBun } from 'std-env'
+import { describe, expect, it } from 'vitest'
+import { PostgresJSDialect, type PostgresJSSql } from '..'
+import type { Database } from './test-setup.js'
+
+describe.skipIf(!isBun)('adapter validation (bun)', () => {
+	it('should throw when the Bun `SQL` instance\'s resolved adapter is not "postgres"', async () => {
+		const db = new Kysely<Database>({
+			dialect: new PostgresJSDialect({
+				postgres: () =>
+					import('bun').then(
+						(mod) =>
+							new mod.SQL('sqlite://:memory:') as unknown as PostgresJSSql,
+					),
+			}),
+		})
+
+		await expect(sql`select 1`.execute(db)).rejects.toThrow(
+			'PostgresJSDialect only supports Bun SQL\'s PostgreSQL adapter, but the instance you passed to it resolved to the "sqlite" adapter.',
+		)
+	})
+})

--- a/tests/test-setup.ts
+++ b/tests/test-setup.ts
@@ -2,9 +2,14 @@ import { type Generated, Kysely } from 'kysely'
 import postgres from 'postgres'
 import { isBun } from 'std-env'
 
-import { PostgresJSDialect, type PostgresJSDialectConfig } from '..'
+import {
+	PostgresJSDialect,
+	type PostgresJSDialectConfig,
+	type PostgresJSSql,
+} from '..'
 
-const CONNECTION_STRING = 'postgres://postgres:postgres@localhost:5432/main'
+export const CONNECTION_STRING =
+	'postgres://postgres:postgres@localhost:5432/main'
 
 export const SUPPORTED_DIALECTS = ['v3', 'bun'] as const
 
@@ -18,7 +23,10 @@ const getDialect = (
 				? new PostgresJSDialect({
 						...config,
 						postgres: () =>
-							import('bun').then((mod) => new mod.SQL(CONNECTION_STRING)),
+							import('bun').then(
+								(mod) =>
+									new mod.SQL(CONNECTION_STRING) as unknown as PostgresJSSql,
+							),
 					})
 				: undefined,
 			v3: new PostgresJSDialect({


### PR DESCRIPTION
Hey 👋 

This PR continues the work @lourd did on #459.

We now `select pg_cancel_backend(pid)` when `Bun.SQL` is used and we're in `"cancel query"` strategy.
We now `select pg_terminate_backend(pid)` when in `"kill session"` strategy.

When `Bun.SQL` is used, we get the session's PID once by running a query.
When `postgres` is used, we get the session's PID from pending query `state.pid`.

We added a `controlPostgres` property to dialect config to decouple these server-side queries from the regular pool's capacity, similarly to how the core PostgreSQL dialect allows passing a separate client for that.

Terminating sessions revealed some quirks/bugs in both `postgres` and `Bun.SQL`. https://github.com/porsager/postgres/issues/1199 was filed.